### PR TITLE
build: disable fpgaperf_counter

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -25,5 +25,5 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 
 opae_add_subdirectory(coreidle)
-opae_add_subdirectory(fpgaperf_counter)
+#opae_add_subdirectory(fpgaperf_counter)
 opae_add_subdirectory(hssi)


### PR DESCRIPTION
Some are not using -DOPAE_LEGACY_TAG, and this is causing a build
conflict when pulling from master.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>